### PR TITLE
Fix README. Add a README example test

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## Description
 
-Simple utilities to add guard clauses to yout JS code.
+Simple utilities to add guard clauses to your JS code.
 
-Guards raises an Error if a given condition is truthy.
+Guards raises an Error if a given condition is falsy.
 
 ## Features
 
@@ -15,19 +15,27 @@ Guards raises an Error if a given condition is truthy.
 
 ## Install
 
+```bash
+npm install simple-guards
 ```
-npm instal simple-guards
-````
+
+If you use `yarn`, just:
+
+```bash
+yarn add simple-guards
+```
 
 ## Usage
 
+The utility exports two methods: `guard` and `guards`.
+
 To set a simple guard:
 
-```
+```js
 import { guard } from "simple-guards";
 
 function division(numerator, denominator) {
-  guard(denominator === 0, "denominator cannot be zero");
+  guard(denominator !== 0, "denominator cannot be zero");
 
   // more awful code
 }
@@ -35,10 +43,9 @@ function division(numerator, denominator) {
 
 You can also pass a function to lazy evaluate an expensive guard:
 
-```
-
+```js
 function division(numerator, denominator) {
-  guard(() => expensiveDetectionOfZero(denominator), "denominator cannot be zero");
+  guard(() => !expensiveDetectionOfZero(denominator), "denominator cannot be zero");
 
   // more awful code
 }
@@ -48,14 +55,14 @@ function division(numerator, denominator) {
 If you want to lazy evaluate many guards you can use the `guards` method to
 avoid excessive wrapper functions:
 
-```
+```js
 import { guards } from "simple-guards";
 
 function division(numerator, denominator) {
-  guards((guard) => {
-    guard(expensiveDetectionOfZero(numerator), "we don't want numerator to be zero");
-    guard(expensiveDetectionOfZero(denominator), "denominator cannot be zero");
-  })
+  guards(guard => {
+    guard(!expensiveDetectionOfZero(numerator), "we don't want numerator to be zero");
+    guard(!expensiveDetectionOfZero(denominator), "denominator cannot be zero");
+  });
 
   // more awful code
 }

--- a/test/guards-test.js
+++ b/test/guards-test.js
@@ -34,5 +34,18 @@ describe("guards", () => {
         expect(() => guard(() => true, "error")).not.toThrow();
       });
     });
+
+    describe("README example", () => {
+      function division(numerator, denominator) {
+        guard(denominator !== 0, "denominator cannot be zero");
+      }
+      it("zero-denominator throws error", () => {
+        expect(() => division(3, 0)).toThrow("Broken guard: denominator cannot be zero");
+      });
+
+      it("non-zero-denominator works", () => {
+        expect(() => division(6, 2)).not.toThrow();
+      });
+    });
   });
 });


### PR DESCRIPTION
`guard` and `guards` method do not work as README explains. They check that condition is **falsy** (not truthy). Fixed README and added a simple test.